### PR TITLE
Fix publish flow by specifying built wheel output location

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build wheels with Maturin
         run: maturin build --release --manylinux --interpreter $(which python)
 
+      - name: Install Twine
+        run: python -m pip install --upgrade twine
+
       - name: Verify wheels
         run: python -m twine check target/wheels/*
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,7 +30,9 @@ jobs:
         run: python -m pip install --upgrade pip maturin
 
       - name: Build wheels with Maturin
-        run: maturin build --release --manylinux --interpreter $(which python)
+        run: |
+          mkdir -p target/wheels
+          maturin build --release --manylinux --interpreter $(which python) --out target/wheels
 
       - name: Install Twine
         run: python -m pip install --upgrade twine
@@ -42,4 +44,4 @@ jobs:
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: python -m twine upload target/wheels/*
+        run: python -m twine upload target/wheels/*.whl

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Maturin
         run: python -m pip install --upgrade pip maturin
 
+      - name: Install Twine
+        run: python -m pip install --upgrade twine
+
       - name: Build wheels with Maturin
         run: maturin build --release --manylinux --interpreter $(which python)
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -33,7 +33,10 @@ jobs:
         run: python -m pip install --upgrade twine
 
       - name: Build wheels with Maturin
-        run: maturin build --release --manylinux --interpreter $(which python)
+        run: |
+          mkdir -p target/wheels
+          maturin build --release --manylinux --interpreter $(which python) --out target/wheels
+
 
       - name: Verify wheels
         run: python -m twine check target/wheels/*
@@ -42,4 +45,4 @@ jobs:
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: python -m twine upload --repository testpypi target/wheels/*
+        run: python -m twine upload --repository testpypi target/wheels/*.whl


### PR DESCRIPTION
Successful test run at https://test.pypi.org/project/sentinel1decoder/