### PR TITLE
Reworked the decoding function to batch packets and multithread decoding

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,6 +9,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +241,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +273,7 @@ dependencies = [
  "num-complex",
  "numpy",
  "pyo3",
+ "rayon",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.27", features = ["extension-module"] }
 numpy = "0.27"
 num-complex = "0.4"
+rayon = "1.10"
 
 [package.metadata.maturin]
 # Optional: set the Python package name if different from the Rust crate name

--- a/rust/src/bypass_decoder.rs
+++ b/rust/src/bypass_decoder.rs
@@ -1,0 +1,164 @@
+//! Bypass decoder implementation.
+//!
+//! This module contains the core bypass decoder logic for Sentinel-1 packets.
+//! Bypass mode encodes samples as simple 10-bit signed integers (1 sign bit + 9 magnitude bits).
+
+use rayon::prelude::*;
+use num_complex::Complex32;
+
+/// Convert a 10-bit unsigned integer to a signed integer.
+///
+/// The first bit is the sign, the next 9 bits are the magnitude.
+///
+/// # Arguments
+///
+/// * `ten_bit` - Raw 10-bit unsigned integer extracted from packet
+///
+/// # Returns
+///
+/// A signed integer value
+fn ten_bit_unsigned_to_signed_int(ten_bit: u16) -> i16 {
+    let sign = if (ten_bit >> 9) & 0x1 == 1 { -1 } else { 1 };
+    sign * ((ten_bit & 0x1FF) as i16)
+}
+
+/// Decode a single channel's data (one quarter of the quad data).
+///
+/// This function decodes a single channel (IE, IO, QE, or QO) which consists of
+/// 10-bit samples packed into bytes. Each sample is 10 bits (1 sign + 9 magnitude).
+/// Four samples fit into 5 bytes (40 bits total).
+///
+/// # Arguments
+///
+/// * `data` - The raw byte data
+/// * `start_byte_idx` - Starting byte position for this channel
+/// * `num_quads` - Total number of quads to decode
+///
+/// # Returns
+///
+/// A vector of decoded sample values as f32
+fn decode_channel(
+    data: &[u8],
+    start_byte_idx: usize,
+    num_quads: usize,
+) -> Result<Vec<f32>, String> {
+    let mut channel_samples = Vec::with_capacity(num_quads);
+    let mut samples_processed = 0;
+    let mut byte_idx = start_byte_idx;
+
+    while samples_processed < num_quads {
+        // We extract 4 samples from every 5 bytes
+        // Sample 1: bits 0-9 from bytes 0-1
+        // Sample 2: bits 2-11 from bytes 1-2
+        // Sample 3: bits 4-13 from bytes 2-3
+        // Sample 4: bits 6-15 from bytes 3-4
+
+        if samples_processed < num_quads {
+            // Sample 1: (data[0] << 2 | data[1] >> 6) & 1023
+            if byte_idx + 1 >= data.len() {
+                return Err("Unexpected end of data when decoding channel".to_string());
+            }
+            let s_code = ((data[byte_idx] as u16) << 2 | (data[byte_idx + 1] as u16) >> 6) & 1023;
+            channel_samples.push(ten_bit_unsigned_to_signed_int(s_code) as f32);
+            samples_processed += 1;
+        } else {
+            break;
+        }
+
+        if samples_processed < num_quads {
+            // Sample 2: (data[1] << 4 | data[2] >> 4) & 1023
+            if byte_idx + 2 >= data.len() {
+                return Err("Unexpected end of data when decoding channel".to_string());
+            }
+            let s_code = ((data[byte_idx + 1] as u16) << 4 | (data[byte_idx + 2] as u16) >> 4) & 1023;
+            channel_samples.push(ten_bit_unsigned_to_signed_int(s_code) as f32);
+            samples_processed += 1;
+        } else {
+            break;
+        }
+
+        if samples_processed < num_quads {
+            // Sample 3: (data[2] << 6 | data[3] >> 2) & 1023
+            if byte_idx + 3 >= data.len() {
+                return Err("Unexpected end of data when decoding channel".to_string());
+            }
+            let s_code = ((data[byte_idx + 2] as u16) << 6 | (data[byte_idx + 3] as u16) >> 2) & 1023;
+            channel_samples.push(ten_bit_unsigned_to_signed_int(s_code) as f32);
+            samples_processed += 1;
+        } else {
+            break;
+        }
+
+        if samples_processed < num_quads {
+            // Sample 4: (data[3] << 8 | data[4] >> 0) & 1023
+            if byte_idx + 4 >= data.len() {
+                return Err("Unexpected end of data when decoding channel".to_string());
+            }
+            let s_code = ((data[byte_idx + 3] as u16) << 8 | (data[byte_idx + 4] as u16) >> 0) & 1023;
+            channel_samples.push(ten_bit_unsigned_to_signed_int(s_code) as f32);
+            samples_processed += 1;
+        } else {
+            break;
+        }
+
+        byte_idx += 5;
+    }
+
+    Ok(channel_samples)
+}
+
+/// Decode bypass data from Sentinel-1 packets.
+///
+/// This is the pure Rust implementation that performs the actual decoding logic.
+/// It has no Python dependencies and returns a Result with Vec<Complex32>.
+///
+/// Bypass mode encodes samples as simple 10-bit signed integers (1 sign bit + 9 magnitude bits).
+/// The data is arranged into IE, IO, QE, QO channels, and each channel is zero-padded
+/// to the next 16-bit word boundary.
+///
+/// # Arguments
+///
+/// * `data` - Raw bytes containing the encoded data
+/// * `num_quads` - Number of quad samples to decode
+///
+/// # Returns
+///
+/// A vector of complex numbers representing the decoded samples. The samples are interleaved:
+/// - `complex(IE[0], QE[0])`, `complex(IO[0], QO[0])`, `complex(IE[1], QE[1])`, `complex(IO[1], QO[1])`, ...
+pub fn decode_single_bypass_packet_inner(data: &[u8], num_quads: usize) -> Result<Vec<Complex32>, String> {
+    // Calculate the number of bytes per channel (aligned to 16-bit word boundary)
+    // Each channel needs ceil((10 * num_quads) / 16) * 2 bytes
+    let num_words = ((num_quads * 10 + 15) / 16) as usize;  // Round up to next 16-bit word
+    let num_bytes_per_channel = num_words * 2;
+
+    // Decode IE channel (starts at byte 0)
+    let ie = decode_channel(data, 0, num_quads)?;
+
+    // Decode IO channel (starts at num_bytes_per_channel)
+    let io = decode_channel(data, num_bytes_per_channel, num_quads)?;
+
+    // Decode QE channel (starts at 2 * num_bytes_per_channel)
+    let qe = decode_channel(data, 2 * num_bytes_per_channel, num_quads)?;
+
+    // Decode QO channel (starts at 3 * num_bytes_per_channel)
+    let qo = decode_channel(data, 3 * num_bytes_per_channel, num_quads)?;
+
+    // Combine channels into interleaved complex samples: IE[i]+QE[i]j, IO[i]+QO[i]j, ...
+    let mut complex_samples = Vec::with_capacity(ie.len() * 2);
+    for i in 0..ie.len() {
+        complex_samples.push(Complex32::new(ie[i], qe[i]));  // IE[i] + QE[i]j
+        complex_samples.push(Complex32::new(io[i], qo[i]));  // IO[i] + QO[i]j
+    }
+
+    Ok(complex_samples)
+}
+
+pub fn decode_batched_bypass_packets_inner(
+    packets: &[Vec<u8>],
+    num_quads: usize,
+) -> Result<Vec<Vec<Complex32>>, String> {
+    packets
+        .par_iter()
+        .map(|packet| decode_single_bypass_packet_inner(packet, num_quads))
+        .collect()
+}

--- a/rust/src/fdbaq_decoder.rs
+++ b/rust/src/fdbaq_decoder.rs
@@ -1,0 +1,267 @@
+//! FDBAQ decoder implementation.
+//!
+//! This module contains the core FDBAQ (Flexible Dynamic Block Adaptive Quantization)
+//! decoding logic for Sentinel-1 packets.
+
+use std::sync::LazyLock;
+use rayon::prelude::*;
+use num_complex::Complex32;
+
+use crate::huffman::{HuffmanDecoderSampleCode, HuffmanDecodingState, HuffmanCode};
+use crate::huffman_codes::get_huffman_codes;
+use crate::sample_value_reconstruction::reconstruct_channel;
+
+// Lazy static cache of decoders for each BRC value
+static DECODERS: [LazyLock<HuffmanDecoderSampleCode>; 5] = [
+    LazyLock::new(|| {
+        let codes = get_huffman_codes(0);
+        HuffmanDecoderSampleCode::from_huffman_codes(codes)
+    }),
+    LazyLock::new(|| {
+        let codes = get_huffman_codes(1);
+        HuffmanDecoderSampleCode::from_huffman_codes(codes)
+    }),
+    LazyLock::new(|| {
+        let codes = get_huffman_codes(2);
+        HuffmanDecoderSampleCode::from_huffman_codes(codes)
+    }),
+    LazyLock::new(|| {
+        let codes = get_huffman_codes(3);
+        HuffmanDecoderSampleCode::from_huffman_codes(codes)
+    }),
+    LazyLock::new(|| {
+        let codes = get_huffman_codes(4);
+        HuffmanDecoderSampleCode::from_huffman_codes(codes)
+    }),
+];
+
+/// Get the decoder for a given BRC value.
+///
+/// # Arguments
+///
+/// * `brc` - Bit Rate Code value (0-4)
+///
+/// # Returns
+///
+/// A reference to the decoder for the given BRC, or `None` if the BRC is invalid.
+fn get_decoder(brc: u8) -> Option<&'static HuffmanDecoderSampleCode> {
+    DECODERS.get(brc as usize).map(LazyLock::force)
+}
+
+/// Reconstruct the bitstream from the excess symbols and the Huffman codes.
+///
+/// Block boundaries do not line up with byte boundaries. Since we work byte-by-byte,
+/// at block boundaries we sometimes return excess symbols beyond the 128th. We therefore
+/// need a method of reconstructing the bits in the byte that were turned into excess symbols.
+/// We can then use these to seed the decoding of the next block.
+///
+/// # Arguments
+///
+/// * `excess_symbols` - The excess symbols to reconstruct the bitstream from
+/// * `excess_symbol_codes` - The Huffman codes used to turn bits into excess symbols
+/// * `state` - The current state. This is the state of the Huffman decoder at the end of the byte containing the block boundary.
+///
+/// # Returns
+///
+/// The reconstructed bitstream
+fn reconstruct_bitstream(excess_symbols: &Vec<(bool, u8)>, excess_symbol_codes: &Vec<HuffmanCode<(bool, u8)>>, state: HuffmanDecodingState) -> HuffmanDecodingState {
+    let mut bitstream = state.state_bits;
+    let mut bitstream_len = state.state_len;
+    for symbol in excess_symbols.iter().rev() {
+        let code = excess_symbol_codes.iter().find(|code| code.symbol == *symbol).unwrap();
+        bitstream |= (code.bits as u16) << bitstream_len;
+        bitstream_len += code.bit_len;
+    }
+    HuffmanDecodingState::new(bitstream, bitstream_len)
+}
+
+
+/// Decode a channel's data (one quarter of the quad data).
+///
+/// This function decodes a single channel (IE, IO, QE, or QO) which consists of
+/// multiple BAQ blocks. Each block may have up to 128 symbols (or fewer for the last block).
+///
+/// # Arguments
+///
+/// * `data` - The raw byte data
+/// * `byte_idx` - Current byte position in the data (will be updated)
+/// * `num_quads` - Total number of quads to decode
+/// * `num_baq_blocks` - Number of BAQ blocks
+/// * `brcs` - Vector of BRC codes (will be updated if `read_brc` is true)
+/// * `read_brc` - If true, read BRC from data; if false, reuse existing BRCs
+///
+/// # Returns
+///
+/// A vector of decoded symbols `(sign, magnitude)` tuples
+fn decode_channel(
+    data: &[u8],
+    byte_idx: &mut usize,
+    num_quads: usize,
+    brcs: &mut Vec<u8>,
+    thidxs: &mut Vec<u8>,
+    read_brc: bool,
+    read_thidx: bool,
+) -> Result<Vec<(bool, u8)>, String> {
+    let mut channel_symbols = Vec::new();
+    let mut values_processed = 0;
+    let mut state = HuffmanDecodingState::zero();
+
+    let num_baq_blocks = (num_quads + 127) / 128;
+
+    for block_idx in 0..num_baq_blocks {
+        let symbols_needed = 128.min(num_quads - values_processed);
+
+        // We need to handle the bits around the block boundary carefully. The previous block may have given us
+        // enough bits for several symbols. On the other hand, it may have given us too few bits to reconstruct
+        // this block's BRC or THIDX, if we need to read them. We therefore need to build a larger state made up
+        // of the remaining bits from the previous byte and an addittional full byte, and then process it manually
+        // rather than using a lookup table.
+        // It's possible this full byte does not exist - one BRC and one symbol can be as few as 5 bits. We need
+        // to handle this case gracefully.
+        let boundary_state_bits: u32;
+        let boundary_state_len: u8;
+        if let Some(&byte) = data.get(*byte_idx) {
+            boundary_state_bits = (state.state_bits as u32) << 8 | byte as u32;
+            boundary_state_len = state.state_len + 8;
+            *byte_idx += 1;
+        } else {
+            boundary_state_bits = state.state_bits as u32;
+            boundary_state_len = state.state_len;
+        }
+
+        // Get or read BRC or THIDX from the boundary state, along with any symbols, then transition into table lookup mode.
+        let brc;
+        let initial_symbols;
+        let decoder: &HuffmanDecoderSampleCode;
+
+        if read_brc {
+            // The first 3 bits of the boundary state are the BRC. The remaining bits are symbols.
+            brc = ((boundary_state_bits >> (boundary_state_len - 3)) & 0x07) as u8;
+            if brc >= 5 {
+                return Err(format!("Invalid BRC value: {}", brc));
+            }
+            brcs.push(brc);
+
+            let remaining_bits = boundary_state_bits & ((1 << (boundary_state_len - 3)) - 1);
+            let remaining_len = boundary_state_len - 3;
+            decoder = get_decoder(brc).ok_or_else(|| format!("Invalid BRC value: {}", brc))?;
+            let (symbols, next_state) = decoder.read_bitstream(remaining_bits, remaining_len);
+            initial_symbols = symbols;
+            state = next_state;
+        } else if read_thidx {
+            // The first 8 bits of the boundary state are the THIDX. The remaining bits are symbols.
+            let thidx = ((boundary_state_bits >> (boundary_state_len - 8)) & 0xFF) as u8;
+            thidxs.push(thidx);
+
+            brc = *brcs.get(block_idx).ok_or_else(|| format!("Not enough BRC codes for block {}", block_idx))?;
+            let remaining_bits = boundary_state_bits & ((1 << (boundary_state_len - 8)) - 1);
+            let remaining_len = boundary_state_len - 8;
+            decoder = get_decoder(brc).ok_or_else(|| format!("Invalid BRC value: {}", brc))?;
+            let (symbols, next_state) = decoder.read_bitstream(remaining_bits, remaining_len);
+            initial_symbols = symbols;
+            state = next_state;
+        } else {
+            brc = *brcs.get(block_idx).ok_or_else(|| format!("Not enough BRC codes for block {}", block_idx))?;
+            decoder = get_decoder(brc).ok_or_else(|| format!("Invalid BRC value: {}", brc))?;
+            let (symbols, next_state) = decoder.read_bitstream(boundary_state_bits, boundary_state_len);
+            initial_symbols = symbols;
+            state = next_state;
+        }
+
+
+        // Start with symbols from BRC byte (if any)
+        let mut block_symbols = initial_symbols;
+
+        // Decode remaining symbols for this block
+        while block_symbols.len() < symbols_needed {
+            if *byte_idx >= data.len() {
+                return Err("Unexpected end of data when decoding symbols".to_string());
+            }
+            let byte = *data.get(*byte_idx)
+                .ok_or_else(|| "Unexpected end of data when decoding symbols".to_string())?;
+            *byte_idx += 1;
+
+            let state_id = state.to_state_id();
+            let (new_symbols, next_state) = decoder.decode_byte(state_id, byte);
+
+            block_symbols.extend(new_symbols);
+            state = next_state;
+        }
+
+        // Take only the symbols we need (in case we decoded too many)
+        if block_symbols.len() > symbols_needed {
+            let excess_symbols = block_symbols.split_off(symbols_needed);
+            let new_block_state = reconstruct_bitstream(&excess_symbols, &decoder.huffman_tree, state);
+            state = new_block_state;
+        }
+
+        channel_symbols.extend(block_symbols);
+        values_processed += symbols_needed;
+    }
+
+    // Align to 16-bit word boundary at the end of each channel
+    if *byte_idx % 2 != 0 {
+        *byte_idx += 1;
+    }
+
+    Ok(channel_symbols)
+}
+
+/// Decode FDBAQ (Flexible Dynamic Block Adaptive Quantization) data from Sentinel-1 packets.
+///
+/// This is the pure Rust implementation that performs the actual decoding logic.
+/// It has no Python dependencies and returns a Result with Vec<Complex32>.
+///
+/// # Arguments
+///
+/// * `data` - Raw bytes containing the encoded data
+/// * `num_quads` - Number of quad samples to decode
+///
+/// # Returns
+///
+/// A vector of complex numbers representing the decoded samples. The samples are interleaved:
+/// - `complex(IE[0], QE[0])`, `complex(IO[0], QO[0])`, `complex(IE[1], QE[1])`, `complex(IO[1], QO[1])`, ...
+pub fn decode_single_fdbaq_packet_inner(data: &[u8], num_quads: usize) -> Result<Vec<Complex32>, String> {
+    let mut byte_idx = 0;
+
+    let mut brcs: Vec<u8> = Vec::new();
+    let mut thidxs: Vec<u8> = Vec::new();
+
+    // Decode IE channel (reads BRCs)
+    let s_ie = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, true, false)?;
+
+    // Decode IO channel (reuses BRCs)
+    let s_io = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, false)?;
+
+    // Decode QE channel (reuses BRCs, reads THIDXs)
+    let s_qe = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, true)?;
+
+    // Decode QO channel (reuses BRCs)
+    let s_qo = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, false)?;
+
+    // Reconstruct the sample values
+    let ie = reconstruct_channel(&s_ie, &brcs, &thidxs);
+    let io = reconstruct_channel(&s_io, &brcs, &thidxs);
+    let qe = reconstruct_channel(&s_qe, &brcs, &thidxs);
+    let qo = reconstruct_channel(&s_qo, &brcs, &thidxs);
+
+    // Combine channels into interleaved complex samples: IE[i]+QE[i]j, IO[i]+QO[i]j, ...
+    let mut complex_samples = Vec::with_capacity(ie.len() * 2);
+    for i in 0..ie.len() {
+        complex_samples.push(Complex32::new(ie[i], qe[i]));  // IE[i] + QE[i]j
+        complex_samples.push(Complex32::new(io[i], qo[i]));  // IO[i] + QO[i]j
+    }
+
+    Ok(complex_samples)
+}
+
+
+pub fn decode_batched_fdbaq_packets_inner(
+    packets: &[Vec<u8>],
+    num_quads: usize,
+) -> Result<Vec<Vec<Complex32>>, String> {
+    packets
+        .par_iter()
+        .map(|packet| decode_single_fdbaq_packet_inner(packet, num_quads))
+        .collect()
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,225 +1,109 @@
 //! Python bindings for Sentinel-1 decoder.
 //!
 //! This module provides Python bindings for the Rust implementation of the
-//! Sentinel-1 FDBAQ decoder.
+//! Sentinel-1 FDBAQ and bypass decoders.
 //!
 //! # Module Organization
 //!
 //! - `huffman.rs`: Core Huffman decoder structures and lookup table building logic
 //! - `huffman_codes.rs`: Huffman code tables for all 5 BRC values
+//! - `fdbaq_decoder.rs`: Core FDBAQ decoding logic
+//! - `bypass_decoder.rs`: Core bypass decoding logic
 //! - `lib.rs`: Python bindings and module setup
 
 use pyo3::prelude::*;
 use pyo3::exceptions::PyValueError;
-use numpy::IntoPyArray;
+use pyo3::types::{PyList, PyBytes};
+use numpy::{PyArray2, IntoPyArray, PyArrayMethods};
 use num_complex::Complex32;
-
-use std::sync::LazyLock;
 
 mod huffman;
 mod huffman_codes;
 mod lookup_tables;
 mod sample_value_reconstruction;
+mod fdbaq_decoder;
+mod bypass_decoder;
 
-use crate::huffman::{HuffmanDecoderSampleCode, HuffmanDecodingState, HuffmanCode};
-use crate::huffman_codes::get_huffman_codes;
-use crate::sample_value_reconstruction::reconstruct_channel;
+use crate::fdbaq_decoder::{decode_single_fdbaq_packet_inner, decode_batched_fdbaq_packets_inner};
+use crate::bypass_decoder::{decode_single_bypass_packet_inner, decode_batched_bypass_packets_inner};
 
-// Lazy static cache of decoders for each BRC value
-static DECODERS: [LazyLock<HuffmanDecoderSampleCode>; 5] = [
-    LazyLock::new(|| {
-        let codes = get_huffman_codes(0);
-        HuffmanDecoderSampleCode::from_huffman_codes(codes)
-    }),
-    LazyLock::new(|| {
-        let codes = get_huffman_codes(1);
-        HuffmanDecoderSampleCode::from_huffman_codes(codes)
-    }),
-    LazyLock::new(|| {
-        let codes = get_huffman_codes(2);
-        HuffmanDecoderSampleCode::from_huffman_codes(codes)
-    }),
-    LazyLock::new(|| {
-        let codes = get_huffman_codes(3);
-        HuffmanDecoderSampleCode::from_huffman_codes(codes)
-    }),
-    LazyLock::new(|| {
-        let codes = get_huffman_codes(4);
-        HuffmanDecoderSampleCode::from_huffman_codes(codes)
-    }),
-];
-
-/// Get the decoder for a given BRC value.
+/// Helper function for batched packet decoding.
+///
+/// This function handles the common logic of validating packets, extracting data,
+/// running the decode function without holding the GIL, and creating the NumPy output array.
 ///
 /// # Arguments
 ///
-/// * `brc` - Bit Rate Code value (0-4)
-///
-/// # Returns
-///
-/// A reference to the decoder for the given BRC, or `None` if the BRC is invalid.
-fn get_decoder(brc: u8) -> Option<&'static HuffmanDecoderSampleCode> {
-    DECODERS.get(brc as usize).map(LazyLock::force)
-}
-
-/// Reconstruct the bitstream from the excess symbols and the Huffman codes.
-///
-/// Block boundaries do not line up with byte boundaries. Since we work byte-by-byte,
-/// at block boundaries we sometimes return excess symbols beyond the 128th. We therefore
-/// need a method of reconstructing the bits in the byte that were turned into excess symbols.
-/// We can then use these to seed the decoding of the next block.
-///
-/// # Arguments
-///
-/// * `excess_symbols` - The excess symbols to reconstruct the bitstream from
-/// * `excess_symbol_codes` - The Huffman codes used to turn bits into excess symbols
-/// * `state` - The current state. This is the state of the Huffman decoder at the end of the byte containing the block boundary.
-///
-/// # Returns
-///
-/// The reconstructed bitstream
-fn reconstruct_bitstream(excess_symbols: &Vec<(bool, u8)>, excess_symbol_codes: &Vec<HuffmanCode<(bool, u8)>>, state: HuffmanDecodingState) -> HuffmanDecodingState {
-    let mut bitstream = state.state_bits;
-    let mut bitstream_len = state.state_len;
-    for symbol in excess_symbols.iter().rev() {
-        let code = excess_symbol_codes.iter().find(|code| code.symbol == *symbol).unwrap();
-        bitstream |= (code.bits as u16) << bitstream_len;
-        bitstream_len += code.bit_len;
-    }
-    HuffmanDecodingState::new(bitstream, bitstream_len)
-}
-
-
-/// Decode a channel's data (one quarter of the quad data).
-///
-/// This function decodes a single channel (IE, IO, QE, or QO) which consists of
-/// multiple BAQ blocks. Each block may have up to 128 symbols (or fewer for the last block).
-///
-/// # Arguments
-///
-/// * `data` - The raw byte data
-/// * `byte_idx` - Current byte position in the data (will be updated)
-/// * `num_quads` - Total number of quads to decode
-/// * `num_baq_blocks` - Number of BAQ blocks
-/// * `brcs` - Vector of BRC codes (will be updated if `read_brc` is true)
-/// * `read_brc` - If true, read BRC from data; if false, reuse existing BRCs
-///
-/// # Returns
-///
-/// A vector of decoded symbols `(sign, magnitude)` tuples
-fn decode_channel(
-    data: &[u8],
-    byte_idx: &mut usize,
+/// * `packets` - Python list of bytes objects
+/// * `num_quads` - Number of quad samples to decode per packet
+/// * `py` - Python GIL token
+/// * `decode_fn` - Function that performs the actual batched decoding
+fn decode_batched_packets_helper<F>(
+    packets: &Bound<'_, PyList>,
     num_quads: usize,
-    brcs: &mut Vec<u8>,
-    thidxs: &mut Vec<u8>,
-    read_brc: bool,
-    read_thidx: bool,
-) -> PyResult<Vec<(bool, u8)>> {
-    let mut channel_symbols = Vec::new();
-    let mut values_processed = 0;
-    let mut state = HuffmanDecodingState::zero();
+    py: Python,
+    decode_fn: F,
+) -> PyResult<Py<PyAny>>
+where
+    F: FnOnce(&[Vec<u8>], usize) -> Result<Vec<Vec<Complex32>>, String> + Send,
+{
+    let num_packets = packets.len();
 
-    let num_baq_blocks = (num_quads + 127) / 128;
-
-    for block_idx in 0..num_baq_blocks {
-        let symbols_needed = 128.min(num_quads - values_processed);
-
-        // We need to handle the bits around the block boundary carefully. The previous block may have given us
-        // enough bits for several symbols. On the other hand, it may have given us too few bits to reconstruct
-        // this block's BRC or THIDX, if we need to read them. We therefore need to build a larger state made up
-        // of the remaining bits from the previous byte and an addittional full byte, and then process it manually
-        // rather than using a lookup table.
-        // It's possible this full byte does not exist - one BRC and one symbol can be as few as 5 bits. We need
-        // to handle this case gracefully.
-        let boundary_state_bits: u32;
-        let boundary_state_len: u8;
-        if let Some(&byte) = data.get(*byte_idx) {
-            boundary_state_bits = (state.state_bits as u32) << 8 | byte as u32;
-            boundary_state_len = state.state_len + 8;
-            *byte_idx += 1;
-        } else {
-            boundary_state_bits = state.state_bits as u32;
-            boundary_state_len = state.state_len;
+    // Validate all items are bytes first
+    for (i, item) in packets.iter().enumerate() {
+        if !item.is_instance_of::<PyBytes>() {
+            return Err(PyValueError::new_err(
+                format!("packets[{}] must be bytes, got {}", i, item.get_type().name()?)
+            ));
         }
-
-        // Get or read BRC or THIDX from the boundary state, along with any symbols, then transition into table lookup mode.
-        let brc;
-        let initial_symbols;
-        let decoder: &HuffmanDecoderSampleCode;
-
-        if read_brc {
-            // The first 3 bits of the boundary state are the BRC. The remaining bits are symbols.
-            brc = ((boundary_state_bits >> (boundary_state_len - 3)) & 0x07) as u8;
-            if brc >= 5 {
-                return Err(PyValueError::new_err(format!("Invalid BRC value: {}", brc)));
-            }
-            brcs.push(brc);
-
-            let remaining_bits = boundary_state_bits & ((1 << (boundary_state_len - 3)) - 1);
-            let remaining_len = boundary_state_len - 3;
-            decoder = get_decoder(brc).ok_or_else(|| PyValueError::new_err(format!("Invalid BRC value: {}", brc)))?;
-            let (symbols, next_state) = decoder.read_bitstream(remaining_bits, remaining_len);
-            initial_symbols = symbols;
-            state = next_state;
-        } else if read_thidx {
-            // The first 8 bits of the boundary state are the THIDX. The remaining bits are symbols.
-            let thidx = ((boundary_state_bits >> (boundary_state_len - 8)) & 0xFF) as u8;
-            thidxs.push(thidx);
-
-            brc = *brcs.get(block_idx).ok_or_else(|| PyValueError::new_err(format!("Not enough BRC codes for block {}", block_idx)))?;
-            let remaining_bits = boundary_state_bits & ((1 << (boundary_state_len - 8)) - 1);
-            let remaining_len = boundary_state_len - 8;
-            decoder = get_decoder(brc).ok_or_else(|| PyValueError::new_err(format!("Invalid BRC value: {}", brc)))?;
-            let (symbols, next_state) = decoder.read_bitstream(remaining_bits, remaining_len);
-            initial_symbols = symbols;
-            state = next_state;
-        } else {
-            brc = *brcs.get(block_idx).ok_or_else(|| PyValueError::new_err(format!("Not enough BRC codes for block {}", block_idx)))?;
-            decoder = get_decoder(brc).ok_or_else(|| PyValueError::new_err(format!("Invalid BRC value: {}", brc)))?;
-            let (symbols, next_state) = decoder.read_bitstream(boundary_state_bits, boundary_state_len);
-            initial_symbols = symbols;
-            state = next_state;
-        }
-
-
-        // Start with symbols from BRC byte (if any)
-        let mut block_symbols = initial_symbols;
-
-        // Decode remaining symbols for this block
-        while block_symbols.len() < symbols_needed {
-            if *byte_idx >= data.len() {
-                return Err(PyValueError::new_err("Unexpected end of data when decoding symbols"));
-            }
-            let byte = *data.get(*byte_idx)
-                .ok_or_else(|| PyValueError::new_err("Unexpected end of data when decoding symbols"))?;
-            *byte_idx += 1;
-
-            let state_id = state.to_state_id();
-            let (new_symbols, next_state) = decoder.decode_byte(state_id, byte);
-
-            block_symbols.extend(new_symbols);
-            state = next_state;
-        }
-
-        // Take only the symbols we need (in case we decoded too many)
-        if block_symbols.len() > symbols_needed {
-            let excess_symbols = block_symbols.split_off(symbols_needed);
-            let new_block_state = reconstruct_bitstream(&excess_symbols, &decoder.huffman_tree, state);
-            state = new_block_state;
-        }
-
-        channel_symbols.extend(block_symbols);
-        values_processed += symbols_needed;
     }
 
-    // Align to 16-bit word boundary at the end of each channel
-    if *byte_idx % 2 != 0 {
-        *byte_idx += 1;
+    // Now extract the data
+    let mut packet_data: Vec<Vec<u8>> = Vec::with_capacity(num_packets);
+    for item in packets.iter() {
+        let bytes_obj = item.cast::<PyBytes>()?;
+        packet_data.push(bytes_obj.as_bytes().to_vec());
     }
 
-    Ok(channel_symbols)
+    // Run the heavy work without holding the GIL
+    let decoded_packets = py
+        .detach(|| decode_fn(&packet_data, num_quads))
+        .map_err(|e| PyValueError::new_err(e))?;
+
+    let num_packets = decoded_packets.len();
+    let samples_per_packet = num_quads * 2;
+
+    // Allocate a 2D NumPy array: (num_packets, samples_per_packet)
+    let output = PyArray2::<Complex32>::zeros(
+        py,
+        [num_packets, samples_per_packet],
+        false,
+    );
+
+    // Copy decoded data into NumPy array
+    for (i, packet_samples) in decoded_packets.iter().enumerate() {
+        debug_assert_eq!(packet_samples.len(), samples_per_packet);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                packet_samples.as_ptr(),
+                output.uget_mut([i, 0]),
+                samples_per_packet,
+            );
+        }
+    }
+
+    Ok(output.into())
 }
+
+#[pyfunction]
+fn decode_batched_fdbaq_packets(
+    packets: &Bound<'_, PyList>,
+    num_quads: usize,
+    py: Python,
+) -> PyResult<Py<PyAny>> {
+    decode_batched_packets_helper(packets, num_quads, py, decode_batched_fdbaq_packets_inner)
+}
+
 
 /// Decode FDBAQ (Flexible Dynamic Block Adaptive Quantization) data from Sentinel-1 packets.
 ///
@@ -233,44 +117,50 @@ fn decode_channel(
 ///
 /// # Returns
 ///
-/// A list of complex numbers representing the decoded samples. The samples are interleaved:
+/// A NumPy array of complex numbers representing the decoded samples. The samples are interleaved:
 /// - `complex(IE[0], QE[0])`, `complex(IO[0], QO[0])`, `complex(IE[1], QE[1])`, `complex(IO[1], QO[1])`, ...
 #[pyfunction]
-fn decode_fdbaq(data: &[u8], num_quads: usize, py: Python) -> PyResult<Py<PyAny>> {
-    let mut byte_idx = 0;
-
-    let mut brcs: Vec<u8> = Vec::new();
-    let mut thidxs: Vec<u8> = Vec::new();
-
-    // Decode IE channel (reads BRCs)
-    let s_ie = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, true, false)?;
-
-    // Decode IO channel (reuses BRCs)
-    let s_io = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, false)?;
-
-    // Decode QE channel (reuses BRCs, reads THIDXs)
-    let s_qe = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, true)?;
-
-    // Decode QO channel (reuses BRCs)
-    let s_qo = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, false)?;
-
-    // Reconstruct the sample values
-    let ie = reconstruct_channel(&s_ie, &brcs, &thidxs);
-    let io = reconstruct_channel(&s_io, &brcs, &thidxs);
-    let qe = reconstruct_channel(&s_qe, &brcs, &thidxs);
-    let qo = reconstruct_channel(&s_qo, &brcs, &thidxs);
-
-    // Combine channels into interleaved complex samples: IE[i]+QE[i]j, IO[i]+QO[i]j, ...
-    // Create a vector of Complex32 (which maps to NumPy's complex64 dtype)
-    let mut complex_samples = Vec::with_capacity(ie.len() * 2);
-    for i in 0..ie.len() {
-        complex_samples.push(Complex32::new(ie[i], qe[i]));  // IE[i] + QE[i]j
-        complex_samples.push(Complex32::new(io[i], qo[i]));  // IO[i] + QO[i]j
-    }
+fn decode_single_fdbaq_packet(data: &[u8], num_quads: usize, py: Python) -> PyResult<Py<PyAny>> {
+    let complex_samples = decode_single_fdbaq_packet_inner(data, num_quads)
+        .map_err(|e| PyValueError::new_err(e))?;
 
     // Create NumPy array with complex64 dtype (two f32s per complex number)
     // into_pyarray creates a PyArray1<Complex32> which NumPy sees as complex64
     Ok(complex_samples.into_pyarray(py).to_owned().into())
+}
+
+/// Decode bypass data from Sentinel-1 packets.
+///
+/// This function decodes bypass-encoded data, where samples are encoded as simple
+/// 10-bit signed integers (1 sign bit + 9 magnitude bits). This is used for
+/// user data format types A and B ("Bypass" or "Decimation Only").
+///
+/// # Arguments
+///
+/// * `data` - Raw bytes containing the encoded data
+/// * `num_quads` - Number of quad samples to decode
+///
+/// # Returns
+///
+/// A NumPy array of complex numbers representing the decoded samples. The samples are interleaved:
+/// - `complex(IE[0], QE[0])`, `complex(IO[0], QO[0])`, `complex(IE[1], QE[1])`, `complex(IO[1], QO[1])`, ...
+#[pyfunction]
+fn decode_single_bypass_packet(data: &[u8], num_quads: usize, py: Python) -> PyResult<Py<PyAny>> {
+    let complex_samples = decode_single_bypass_packet_inner(data, num_quads)
+        .map_err(|e| PyValueError::new_err(e))?;
+
+    // Create NumPy array with complex64 dtype (two f32s per complex number)
+    // into_pyarray creates a PyArray1<Complex32> which NumPy sees as complex64
+    Ok(complex_samples.into_pyarray(py).to_owned().into())
+}
+
+#[pyfunction]
+fn decode_batched_bypass_packets(
+    packets: &Bound<'_, PyList>,
+    num_quads: usize,
+    py: Python,
+) -> PyResult<Py<PyAny>> {
+    decode_batched_packets_helper(packets, num_quads, py, decode_batched_bypass_packets_inner)
 }
 
 /// Initialize the Python module.
@@ -279,6 +169,9 @@ fn decode_fdbaq(data: &[u8], num_quads: usize, py: Python) -> PyResult<Py<PyAny>
 /// all the functions and types exposed to Python.
 #[pymodule]
 fn _sentinel1decoder(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(decode_fdbaq, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_single_fdbaq_packet, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_batched_fdbaq_packets, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_single_bypass_packet, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_batched_bypass_packets, m)?)?;
     Ok(())
 }

--- a/src/sentinel1decoder/_sentinel1decoder.pyi
+++ b/src/sentinel1decoder/_sentinel1decoder.pyi
@@ -1,8 +1,10 @@
 """Type stubs for sentinel1decoder Rust extension module."""
 
+from typing import List
+
 import numpy as np
 
-def decode_fdbaq(
+def decode_single_fdbaq_packet(
     data: bytes,
     num_quads: int,
 ) -> np.ndarray:
@@ -20,5 +22,63 @@ def decode_fdbaq(
         - complex(IE[0], QE[0]), complex(IO[0], QO[0]), complex(IE[1], QE[1]), complex(IO[1], QO[1]), ...
 
         The array has shape (num_quads * 2,) and dtype complex64 (which uses float32 for real and imaginary parts).
+    """
+    ...
+
+def decode_batched_fdbaq_packets(
+    packets: List[bytes],
+    num_quads: int,
+) -> np.ndarray:
+    """Decode multiple FDBAQ packets in parallel.
+
+    This function decodes multiple FDBAQ-encoded packets using multithreading for improved performance.
+
+    Args:
+        packets: List of raw bytes, each containing encoded data for one packet
+        num_quads: Number of quad samples to decode per packet
+
+    Returns:
+        A NumPy array of complex64 with shape (num_packets, num_quads * 2). Each row contains
+        the decoded samples for one packet, interleaved as IE+QE*j, IO+QO*j, ...
+    """
+    ...
+
+def decode_single_bypass_packet(
+    data: bytes,
+    num_quads: int,
+) -> np.ndarray:
+    """Decode bypass data from Sentinel-1 packets.
+
+    This function decodes bypass-encoded data, where samples are encoded as simple
+    10-bit signed integers (1 sign bit + 9 magnitude bits). This is used for
+    user data format types A and B ("Bypass" or "Decimation Only").
+
+    Args:
+        data: Raw bytes containing the encoded data
+        num_quads: Number of quad samples to decode
+
+    Returns:
+        A NumPy array of complex64 representing the decoded samples. The samples are interleaved:
+        - complex(IE[0], QE[0]), complex(IO[0], QO[0]), complex(IE[1], QE[1]), complex(IO[1], QO[1]), ...
+
+        The array has shape (num_quads * 2,) and dtype complex64.
+    """
+    ...
+
+def decode_batched_bypass_packets(
+    packets: List[bytes],
+    num_quads: int,
+) -> np.ndarray:
+    """Decode multiple bypass packets in parallel.
+
+    This function decodes multiple bypass-encoded packets using multithreading for improved performance.
+
+    Args:
+        packets: List of raw bytes, each containing encoded data for one packet
+        num_quads: Number of quad samples to decode per packet
+
+    Returns:
+        A NumPy array of complex64 with shape (num_packets, num_quads * 2). Each row contains
+        the decoded samples for one packet, interleaved as IE+QE*j, IO+QO*j, ...
     """
     ...

--- a/src/sentinel1decoder/_user_data_decoder.py
+++ b/src/sentinel1decoder/_user_data_decoder.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sentinel1decoder._bypass_decoder import BypassDecoder
 from sentinel1decoder._sample_code import SampleCode
-from sentinel1decoder._sentinel1decoder import decode_fdbaq
+from sentinel1decoder._sentinel1decoder import decode_single_fdbaq_packet
 
 
 def to_sample_codes(tuples: List[Tuple[bool, int]]) -> List[SampleCode]:
@@ -78,7 +78,7 @@ class UserDataDecoder:
         elif self.baq_mode in (12, 13, 14):
             # FDBAQ data uses various types of Huffman encoding.
             # Rust implementation returns NumPy array of complex64 directly
-            decoded_data = decode_fdbaq(self.data, self.num_quads)
+            decoded_data = decode_single_fdbaq_packet(self.data, self.num_quads)
 
         else:
             logging.error(f"Attempted to decode using invalid BAQ mode: {self.baq_mode}")

--- a/tests/test_bypass_decoder_rust.py
+++ b/tests/test_bypass_decoder_rust.py
@@ -1,0 +1,222 @@
+import numpy as np
+
+from sentinel1decoder._sentinel1decoder import (
+    decode_batched_bypass_packets,
+    decode_single_bypass_packet,
+)
+
+from .data_generation_utils import pack_10bit_samples
+
+
+def test_decoding() -> None:
+    # Default case - 8 * 10-bit words per channel packs exactly into 10 * 8-bit bytes, so no padding
+    data = pack_10bit_samples(np.arange(32).tolist())
+    decoded = decode_single_bypass_packet(data, 8)
+
+    # Rust decoder returns interleaved complex samples: IE[0]+QE[0]j, IO[0]+QO[0]j, IE[1]+QE[1]j, IO[1]+QO[1]j, ...
+    # Extract individual channels
+    i_evens = decoded[0::2].real  # Real part of even indices (IE)
+    i_odds = decoded[1::2].real  # Real part of odd indices (IO)
+    q_evens = decoded[0::2].imag  # Imaginary part of even indices (QE)
+    q_odds = decoded[1::2].imag  # Imaginary part of odd indices (QO)
+
+    assert np.array_equal(i_evens, np.arange(8))
+    assert np.array_equal(i_odds, np.arange(8, 16))
+    assert np.array_equal(q_evens, np.arange(16, 24))
+    assert np.array_equal(q_odds, np.arange(24, 32))
+
+    # 4 channels, 3 quads each. 30 bits total per channel, so 2 bits padding
+    ie = [200, 201, 202]
+    io = [300, 301, 302]
+    qe = [400, 401, 402]
+    qo = [500, 501, 502]
+    data = pack_10bit_samples(ie) + pack_10bit_samples(io) + pack_10bit_samples(qe) + pack_10bit_samples(qo)
+    decoded = decode_single_bypass_packet(data, 3)
+
+    i_evens = decoded[0::2].real
+    i_odds = decoded[1::2].real
+    q_evens = decoded[0::2].imag
+    q_odds = decoded[1::2].imag
+
+    assert np.array_equal(i_evens, ie)
+    assert np.array_equal(i_odds, io)
+    assert np.array_equal(q_evens, qe)
+    assert np.array_equal(q_odds, qo)
+
+    # 4 channels, 4 quads each. 40 bits total per channel, so 8 bits padding
+    ie = [-200, -201, -202, -203]
+    io = [-300, -301, -302, -303]
+    qe = [-400, -401, -402, -403]
+    qo = [-500, -501, -502, -503]
+    data = pack_10bit_samples(ie) + pack_10bit_samples(io) + pack_10bit_samples(qe) + pack_10bit_samples(qo)
+    decoded = decode_single_bypass_packet(data, 4)
+
+    i_evens = decoded[0::2].real
+    i_odds = decoded[1::2].real
+    q_evens = decoded[0::2].imag
+    q_odds = decoded[1::2].imag
+
+    assert np.array_equal(i_evens, ie)
+    assert np.array_equal(i_odds, io)
+    assert np.array_equal(q_evens, qe)
+    assert np.array_equal(q_odds, qo)
+
+
+def test_batched_bypass_decoder_same_config() -> None:
+    """Test batched decode with multiple packets of the same configuration."""
+    # Create test data: 4 channels, 8 quads each
+    num_quads = 8
+    ie = np.arange(8)
+    io = np.arange(8, 16)
+    qe = np.arange(16, 24)
+    qo = np.arange(24, 32)
+
+    # Create a single packet
+    single_packet_data = (
+        pack_10bit_samples(ie.tolist())
+        + pack_10bit_samples(io.tolist())
+        + pack_10bit_samples(qe.tolist())
+        + pack_10bit_samples(qo.tolist())
+    )
+
+    # Generate multiple identical packets
+    num_packets = 5
+    packet_data_list = [single_packet_data for _ in range(num_packets)]
+
+    # Decode using batched function
+    batched_result = decode_batched_bypass_packets(packet_data_list, num_quads)
+
+    # Check array properties
+    assert isinstance(batched_result, np.ndarray)
+    assert batched_result.dtype == np.complex64
+    assert batched_result.shape == (num_packets, num_quads * 2)
+
+    # Decode one packet individually for expected values
+    single_result = decode_single_bypass_packet(single_packet_data, num_quads)
+
+    # All packets should decode to the same result
+    for i in range(num_packets):
+        np.testing.assert_array_equal(
+            batched_result[i], single_result, err_msg=f"Packet {i} should match single decode result"
+        )
+
+    # Verify expected values
+    i_evens = single_result[0::2].real
+    i_odds = single_result[1::2].real
+    q_evens = single_result[0::2].imag
+    q_odds = single_result[1::2].imag
+
+    assert np.array_equal(i_evens, ie)
+    assert np.array_equal(i_odds, io)
+    assert np.array_equal(q_evens, qe)
+    assert np.array_equal(q_odds, qo)
+
+    # Verify batched result also has correct values
+    for i in range(num_packets):
+        batched_i_evens = batched_result[i][0::2].real
+        batched_i_odds = batched_result[i][1::2].real
+        batched_q_evens = batched_result[i][0::2].imag
+        batched_q_odds = batched_result[i][1::2].imag
+
+        assert np.array_equal(batched_i_evens, ie)
+        assert np.array_equal(batched_i_odds, io)
+        assert np.array_equal(batched_q_evens, qe)
+        assert np.array_equal(batched_q_odds, qo)
+
+
+def test_batched_bypass_decoder_different_configs() -> None:
+    """Test batched decode with multiple packets of different configurations."""
+    num_quads = 4
+
+    # Create different test data for each packet
+    # Note: 10-bit signed integers have range -511 to +511
+    packet_configs = [
+        {
+            "ie": [100, 101, 102, 103],
+            "io": [200, 201, 202, 203],
+            "qe": [300, 301, 302, 303],
+            "qo": [400, 401, 402, 403],
+        },
+        {
+            "ie": [-100, -101, -102, -103],
+            "io": [-200, -201, -202, -203],
+            "qe": [-300, -301, -302, -303],
+            "qo": [-400, -401, -402, -403],
+        },
+        {
+            "ie": [50, 51, 52, 53],
+            "io": [150, 151, 152, 153],
+            "qe": [250, 251, 252, 253],
+            "qo": [350, 351, 352, 353],
+        },
+        {
+            "ie": [0, 1, 2, 3],
+            "io": [10, 11, 12, 13],
+            "qe": [20, 21, 22, 23],
+            "qo": [30, 31, 32, 33],
+        },
+        {
+            "ie": [450, 451, 452, 453],
+            "io": [480, 481, 482, 483],
+            "qe": [500, 501, 502, 503],
+            "qo": [510, 511, -511, -510],
+        },
+    ]
+
+    # Create packet data for each configuration
+    packet_data_list = []
+    expected_results = []
+
+    for config in packet_configs:
+        packet_data = (
+            pack_10bit_samples(config["ie"])
+            + pack_10bit_samples(config["io"])
+            + pack_10bit_samples(config["qe"])
+            + pack_10bit_samples(config["qo"])
+        )
+        packet_data_list.append(packet_data)
+
+        # Create expected result for this packet
+        ie = np.array(config["ie"], dtype=np.float32)
+        io = np.array(config["io"], dtype=np.float32)
+        qe = np.array(config["qe"], dtype=np.float32)
+        qo = np.array(config["qo"], dtype=np.float32)
+
+        # Interleave as IE+QE*j, IO+QO*j
+        expected = np.empty(num_quads * 2, dtype=np.complex64)
+        expected[0::2] = ie + 1j * qe  # Even indices: IE+QE*j
+        expected[1::2] = io + 1j * qo  # Odd indices: IO+QO*j
+        expected_results.append(expected)
+
+    # Decode using batched function
+    batched_result = decode_batched_bypass_packets(packet_data_list, num_quads)
+
+    # Check array properties
+    assert isinstance(batched_result, np.ndarray)
+    assert batched_result.dtype == np.complex64
+    assert batched_result.shape == (len(packet_configs), num_quads * 2)
+
+    # Verify each packet decodes correctly
+    for i, (packet_data, expected) in enumerate(zip(packet_data_list, expected_results)):
+        # Decode individually for comparison
+        single_result = decode_single_bypass_packet(packet_data, num_quads)
+
+        # Batched result should match single decode
+        np.testing.assert_array_equal(
+            batched_result[i], single_result, err_msg=f"Packet {i} batched result should match single decode result"
+        )
+
+        # Batched result should match expected values
+        np.testing.assert_array_equal(batched_result[i], expected, err_msg=f"Packet {i} should match expected values")
+
+        # Verify individual channels
+        config = packet_configs[i]
+        batched_i_evens = batched_result[i][0::2].real
+        batched_i_odds = batched_result[i][1::2].real
+        batched_q_evens = batched_result[i][0::2].imag
+        batched_q_odds = batched_result[i][1::2].imag
+
+        assert np.array_equal(batched_i_evens, config["ie"]), f"Packet {i} IE channel mismatch"
+        assert np.array_equal(batched_i_odds, config["io"]), f"Packet {i} IO channel mismatch"
+        assert np.array_equal(batched_q_evens, config["qe"]), f"Packet {i} QE channel mismatch"
+        assert np.array_equal(batched_q_odds, config["qo"]), f"Packet {i} QO channel mismatch"

--- a/tests/test_fdbaq_decoder_rust.py
+++ b/tests/test_fdbaq_decoder_rust.py
@@ -4,7 +4,10 @@ import numpy as np
 
 from sentinel1decoder._sample_code import SampleCode
 from sentinel1decoder._sample_value_reconstruction import reconstruct_channel_vals
-from sentinel1decoder._sentinel1decoder import decode_fdbaq
+from sentinel1decoder._sentinel1decoder import (
+    decode_batched_fdbaq_packets,
+    decode_single_fdbaq_packet,
+)
 
 from .data_generation_utils import PacketConfig, create_synthetic_fdbaq_data, pack_bits
 
@@ -75,7 +78,7 @@ def assert_complex_arrays_close(
 def test_fdbaq_decoder_brc0() -> None:
     config = PacketConfig(num_quads=128, const_brc=0, const_thidx=0)
     data = create_synthetic_fdbaq_data(config, "00")
-    complex_samples = decode_fdbaq(data, 128)
+    complex_samples = decode_single_fdbaq_packet(data, 128)
 
     # Check array properties
     assert isinstance(complex_samples, np.ndarray)
@@ -94,7 +97,7 @@ def test_fdbaq_decoder_brc0() -> None:
 
     config = PacketConfig(num_quads=1234, const_brc=0, const_thidx=63)
     data = create_synthetic_fdbaq_data(config, "010")
-    complex_samples = decode_fdbaq(data, 1234)
+    complex_samples = decode_single_fdbaq_packet(data, 1234)
 
     assert len(complex_samples) == 1234 * 2
     num_blocks = math.ceil(1234 / 128)
@@ -109,7 +112,7 @@ def test_fdbaq_decoder_brc0() -> None:
 
     config = PacketConfig(num_quads=37, const_brc=0, const_thidx=2)
     data = create_synthetic_fdbaq_data(config, "1110")
-    complex_samples = decode_fdbaq(data, 37)
+    complex_samples = decode_single_fdbaq_packet(data, 37)
 
     assert len(complex_samples) == 37 * 2
     num_blocks = math.ceil(37 / 128)
@@ -124,7 +127,7 @@ def test_fdbaq_decoder_brc0() -> None:
 
     config = PacketConfig(num_quads=55, const_brc=0, const_thidx=0)
     data = create_synthetic_fdbaq_data(config, "1111")
-    complex_samples = decode_fdbaq(data, 55)
+    complex_samples = decode_single_fdbaq_packet(data, 55)
 
     assert len(complex_samples) == 55 * 2
     num_blocks = math.ceil(55 / 128)
@@ -139,7 +142,7 @@ def test_fdbaq_decoder_brc0() -> None:
 
     config = PacketConfig(num_quads=123, const_brc=0, const_thidx=3)
     data = create_synthetic_fdbaq_data(config, "0111")
-    complex_samples = decode_fdbaq(data, 123)
+    complex_samples = decode_single_fdbaq_packet(data, 123)
 
     assert len(complex_samples) == 123 * 2
     num_blocks = math.ceil(123 / 128)
@@ -156,7 +159,7 @@ def test_fdbaq_decoder_brc0() -> None:
 def test_fdbaq_decoder_brc1() -> None:
     config = PacketConfig(num_quads=1234, const_brc=1, const_thidx=0)
     data = create_synthetic_fdbaq_data(config, "00")
-    complex_samples = decode_fdbaq(data, 1234)
+    complex_samples = decode_single_fdbaq_packet(data, 1234)
 
     assert len(complex_samples) == 1234 * 2
     num_blocks = math.ceil(1234 / 128)
@@ -171,7 +174,7 @@ def test_fdbaq_decoder_brc1() -> None:
 
     config = PacketConfig(num_quads=42, const_brc=1, const_thidx=63)
     data = create_synthetic_fdbaq_data(config, "010")
-    complex_samples = decode_fdbaq(data, 42)
+    complex_samples = decode_single_fdbaq_packet(data, 42)
 
     assert len(complex_samples) == 42 * 2
     num_blocks = math.ceil(42 / 128)
@@ -186,7 +189,7 @@ def test_fdbaq_decoder_brc1() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=1, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "11111")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -201,7 +204,7 @@ def test_fdbaq_decoder_brc1() -> None:
 
     config = PacketConfig(num_quads=101, const_brc=1, const_thidx=101)
     data = create_synthetic_fdbaq_data(config, "01110")
-    complex_samples = decode_fdbaq(data, 101)
+    complex_samples = decode_single_fdbaq_packet(data, 101)
 
     assert len(complex_samples) == 101 * 2
     num_blocks = math.ceil(101 / 128)
@@ -218,7 +221,7 @@ def test_fdbaq_decoder_brc1() -> None:
 def test_fdbaq_decoder_brc2() -> None:
     config = PacketConfig(num_quads=1234, const_brc=2, const_thidx=0)
     data = create_synthetic_fdbaq_data(config, "00")
-    complex_samples = decode_fdbaq(data, 1234)
+    complex_samples = decode_single_fdbaq_packet(data, 1234)
 
     assert len(complex_samples) == 1234 * 2
     num_blocks = math.ceil(1234 / 128)
@@ -233,7 +236,7 @@ def test_fdbaq_decoder_brc2() -> None:
 
     config = PacketConfig(num_quads=42, const_brc=2, const_thidx=63)
     data = create_synthetic_fdbaq_data(config, "0111111")
-    complex_samples = decode_fdbaq(data, 42)
+    complex_samples = decode_single_fdbaq_packet(data, 42)
 
     assert len(complex_samples) == 42 * 2
     num_blocks = math.ceil(42 / 128)
@@ -248,7 +251,7 @@ def test_fdbaq_decoder_brc2() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=2, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "1111111")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -263,7 +266,7 @@ def test_fdbaq_decoder_brc2() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=2, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "1111110")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -280,7 +283,7 @@ def test_fdbaq_decoder_brc2() -> None:
 def test_fdbaq_decoder_brc3() -> None:
     config = PacketConfig(num_quads=1234, const_brc=3, const_thidx=0)
     data = create_synthetic_fdbaq_data(config, "000")
-    complex_samples = decode_fdbaq(data, 1234)
+    complex_samples = decode_single_fdbaq_packet(data, 1234)
 
     assert len(complex_samples) == 1234 * 2
     num_blocks = math.ceil(1234 / 128)
@@ -295,7 +298,7 @@ def test_fdbaq_decoder_brc3() -> None:
 
     config = PacketConfig(num_quads=42, const_brc=3, const_thidx=63)
     data = create_synthetic_fdbaq_data(config, "110")
-    complex_samples = decode_fdbaq(data, 42)
+    complex_samples = decode_single_fdbaq_packet(data, 42)
 
     assert len(complex_samples) == 42 * 2
     num_blocks = math.ceil(42 / 128)
@@ -310,7 +313,7 @@ def test_fdbaq_decoder_brc3() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=3, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "111111111")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -325,7 +328,7 @@ def test_fdbaq_decoder_brc3() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=3, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "111111110")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -340,7 +343,7 @@ def test_fdbaq_decoder_brc3() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=3, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "011111111")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -357,7 +360,7 @@ def test_fdbaq_decoder_brc3() -> None:
 def test_fdbaq_decoder_brc4() -> None:
     config = PacketConfig(num_quads=1234, const_brc=4, const_thidx=0)
     data = create_synthetic_fdbaq_data(config, "000")
-    complex_samples = decode_fdbaq(data, 1234)
+    complex_samples = decode_single_fdbaq_packet(data, 1234)
 
     assert len(complex_samples) == 1234 * 2
     num_blocks = math.ceil(1234 / 128)
@@ -372,7 +375,7 @@ def test_fdbaq_decoder_brc4() -> None:
 
     config = PacketConfig(num_quads=42, const_brc=4, const_thidx=63)
     data = create_synthetic_fdbaq_data(config, "1100")
-    complex_samples = decode_fdbaq(data, 42)
+    complex_samples = decode_single_fdbaq_packet(data, 42)
 
     assert len(complex_samples) == 42 * 2
     num_blocks = math.ceil(42 / 128)
@@ -387,7 +390,7 @@ def test_fdbaq_decoder_brc4() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=4, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "1111111111")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -402,7 +405,7 @@ def test_fdbaq_decoder_brc4() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=4, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "1111111110")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -417,7 +420,7 @@ def test_fdbaq_decoder_brc4() -> None:
 
     config = PacketConfig(num_quads=99, const_brc=4, const_thidx=11)
     data = create_synthetic_fdbaq_data(config, "0111111111")
-    complex_samples = decode_fdbaq(data, 99)
+    complex_samples = decode_single_fdbaq_packet(data, 99)
 
     assert len(complex_samples) == 99 * 2
     num_blocks = math.ceil(99 / 128)
@@ -484,7 +487,7 @@ def test_fdbaq_decoder_variable_brc() -> None:
     )
     data = ie_bits + io_bits + qe_bits + qo_bits
 
-    complex_samples = decode_fdbaq(data, 128 * 5)
+    complex_samples = decode_single_fdbaq_packet(data, 128 * 5)
 
     # Check array properties
     assert len(complex_samples) == (128 * 5) * 2
@@ -506,3 +509,146 @@ def test_fdbaq_decoder_variable_brc() -> None:
     expected_array[0::2] = ie_qe  # Even indices: IE+QE*j
     expected_array[1::2] = io_qo  # Odd indices: IO+QO*j
     assert_complex_arrays_close(complex_samples, expected_array, rtol=1e-5, atol=1e-6)
+
+
+def test_batched_fdbaq_decoder_same_config() -> None:
+    """Test batched decode with multiple packets of the same configuration."""
+    # Create multiple packets with same config
+    config = PacketConfig(num_quads=128, const_brc=1, const_thidx=5)
+    num_packets = 5
+    huffman_pattern = "010"
+
+    # Generate multiple identical packets
+    packet_data_list = [create_synthetic_fdbaq_data(config, huffman_pattern) for _ in range(num_packets)]
+
+    # Decode using batched function
+    batched_result = decode_batched_fdbaq_packets(packet_data_list, config.num_quads)
+
+    # Check array properties
+    assert isinstance(batched_result, np.ndarray)
+    assert batched_result.dtype == np.complex64
+    assert batched_result.shape == (num_packets, config.num_quads * 2)
+
+    # Decode one packet individually for expected values
+    single_result = decode_single_fdbaq_packet(packet_data_list[0], config.num_quads)
+
+    # All packets should decode to the same result
+    for i in range(num_packets):
+        np.testing.assert_array_equal(
+            batched_result[i], single_result, err_msg=f"Packet {i} should match single decode result"
+        )
+
+    # Verify expected values match reconstruction
+    num_blocks = math.ceil(config.num_quads / 128)
+    sample_codes = [SampleCode(0, 1)] * config.num_quads
+    expected_vals = reconstruct_channel_vals(
+        sample_codes, [config.const_brc] * num_blocks, [config.const_thidx] * num_blocks, config.num_quads
+    )
+    ie_qe = np.array([complex(ie, qe) for ie, qe in zip(expected_vals, expected_vals)], dtype=np.complex64)
+    io_qo = np.array([complex(io, qo) for io, qo in zip(expected_vals, expected_vals)], dtype=np.complex64)
+    expected_array = np.empty(len(ie_qe) * 2, dtype=np.complex64)
+    expected_array[0::2] = ie_qe  # Even indices: IE+QE*j
+    expected_array[1::2] = io_qo  # Odd indices: IO+QO*j
+
+    assert_complex_arrays_close(batched_result[0], expected_array, rtol=1e-5, atol=1e-6)
+
+
+def test_batched_fdbaq_decoder_different_configs() -> None:
+    """Test batched decode with multiple packets of different configurations."""
+    # The batched function expects all packets to have the same num_quads
+    # So we test with packets that have the same num_quads but different BRC/THIDX/patterns
+    num_quads = 128
+    packet_configs_same_size = [
+        PacketConfig(num_quads=num_quads, const_brc=0, const_thidx=0),
+        PacketConfig(num_quads=num_quads, const_brc=1, const_thidx=5),
+        PacketConfig(num_quads=num_quads, const_brc=2, const_thidx=10),
+        PacketConfig(num_quads=num_quads, const_brc=3, const_thidx=20),
+        PacketConfig(num_quads=num_quads, const_brc=4, const_thidx=30),
+    ]
+
+    huffman_patterns_same_size = [
+        "00",  # BRC 0: sign=0, magnitude=0
+        "010",  # BRC 1: sign=0, magnitude=1
+        "0111111",  # BRC 2: sign=0, magnitude=6
+        "111111111",  # BRC 3: sign=1, magnitude=9
+        "1111111111",  # BRC 4: sign=1, magnitude=15
+    ]
+
+    # Map huffman patterns to their documented magnitudes
+    pattern_to_magnitude = {
+        "00": 0,
+        "010": 1,
+        "0111111": 6,
+        "111111111": 9,
+        "1111111111": 15,
+    }
+
+    # Create packet data for each configuration
+    packet_data_list = []
+    expected_results = []
+
+    for config, huffman_pattern in zip(packet_configs_same_size, huffman_patterns_same_size):
+        packet_data = create_synthetic_fdbaq_data(config, huffman_pattern)
+        packet_data_list.append(packet_data)
+
+        # Decode individually to get expected result
+        single_result = decode_single_fdbaq_packet(packet_data, num_quads)
+        expected_results.append(single_result)
+
+    # Decode using batched function
+    batched_result = decode_batched_fdbaq_packets(packet_data_list, num_quads)
+
+    # Check array properties
+    assert isinstance(batched_result, np.ndarray)
+    assert batched_result.dtype == np.complex64
+    assert batched_result.shape == (len(packet_configs_same_size), num_quads * 2)
+
+    # Verify each packet decodes correctly
+    for i, (packet_data, expected) in enumerate(zip(packet_data_list, expected_results)):
+        # Batched result should match single decode
+        try:
+            assert_complex_arrays_close(batched_result[i], expected, rtol=1e-5, atol=1e-6)
+        except AssertionError as e:
+            # Add diagnostic information about packet ordering
+            error_msg = [f"Packet {i} batched result should match single decode result: {e}"]
+            error_msg.append("\nFirst 10 values of each packet (in returned order):")
+            for j in range(len(packet_configs_same_size)):
+                packet_vals = batched_result[j][:10]
+                error_msg.append(f"  Packet {j}: {packet_vals}")
+            error_msg.append("\nFirst 10 values of expected result for this packet:")
+            error_msg.append(f"  Expected: {expected[:10]}")
+            error_msg.append(f"  Actual:   {batched_result[i][:10]}")
+            raise AssertionError("\n".join(error_msg)) from e
+
+        # Verify expected values match reconstruction
+        config = packet_configs_same_size[i]
+        num_blocks = math.ceil(config.num_quads / 128)
+
+        # Extract sign and magnitude from huffman pattern
+        huffman_pattern = huffman_patterns_same_size[i]
+        sign = int(huffman_pattern[0])
+        magnitude = pattern_to_magnitude[huffman_pattern]
+
+        sample_codes = [SampleCode(sign, magnitude)] * config.num_quads
+        expected_vals = reconstruct_channel_vals(
+            sample_codes, [config.const_brc] * num_blocks, [config.const_thidx] * num_blocks, config.num_quads
+        )
+        ie_qe = np.array([complex(ie, qe) for ie, qe in zip(expected_vals, expected_vals)], dtype=np.complex64)
+        io_qo = np.array([complex(io, qo) for io, qo in zip(expected_vals, expected_vals)], dtype=np.complex64)
+        expected_array = np.empty(len(ie_qe) * 2, dtype=np.complex64)
+        expected_array[0::2] = ie_qe  # Even indices: IE+QE*j
+        expected_array[1::2] = io_qo  # Odd indices: IO+QO*j
+
+        try:
+            assert_complex_arrays_close(batched_result[i], expected_array, rtol=1e-5, atol=1e-6)
+        except AssertionError as e:
+            # Add diagnostic information about packet ordering
+            error_msg = [f"Packet {i} should match expected reconstructed values: {e}"]
+            error_msg.append("\nFirst 10 values of each packet (in returned order):")
+            for j in range(len(packet_configs_same_size)):
+                packet_vals = batched_result[j][:10]
+                error_msg.append(f"  Packet {j}: {packet_vals}")
+            error_msg.append("\nFirst 10 values of expected reconstructed result for this packet:")
+            error_msg.append(f"  Expected: {expected_array[:10]}")
+            error_msg.append(f"  Actual:   {batched_result[i][:10]}")
+            raise AssertionError("\n".join(error_msg)) from e


### PR DESCRIPTION
This change migrates the Level0Decoder to batch multiple packets together, then pass these to Rust for multithreaded decoding. As part of this change, also migrated the simpler bypass decoder to Rust. An additional constraint introduced by this change is the requirement for constant BAQ Mode in the decode_packets function.

Testing against an arbitrary stripmap collect over Santos, Brazil resulted in a ~30 second decoding time, down from ~40 minutes with the original pure python, unoptimized version.