### PR TITLE
Drop python 3.8 support, add 3.12 and 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Dropped Python 3.8 support; added Python 3.12 and 3.13 support (requires Python 3.9–3.13).
+- Raised minimum NumPy version to 2.0.
+
 ### Planned
 - BAQ mode C (3/4/5-bit) decoding
 - Full sub-commutated data decoding

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The core decoding functions are implemented in Rust and run multithreaded, so I/
 pip install sentinel1decoder
 ```
 
-Requires Python 3.8+, NumPy, and Pandas.
+Requires Python 3.9–3.13, NumPy 2.0+, and Pandas.
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.24",  # Minimum version compatible with rust-numpy 0.27
+    "numpy>=2.0",
     "pandas",
 ]
 
@@ -53,7 +53,7 @@ python-source = "src"
 module-name = "sentinel1decoder._sentinel1decoder"
 manifest-path = "rust/Cargo.toml"
 manylinux = "2_34"
-interpreter = ["python3.8", "python3.9", "python3.10", "python3.11"]
+interpreter = ["python3.9", "python3.10", "python3.11", "python3.12", "python3.13"]
 
 [tool.black]
 line-length = 120

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "sentinel1decoder"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "num-complex",
  "numpy",


### PR DESCRIPTION
Manylinux dropped python 3.8 support, which broke CI. Rather than attempting to support this old version, this PR updates project dependencies to require python 3.9+. As part of this change, we now require numpy >2.0.