### PR TITLE
Stylistic tweaks for baq decoder

### DIFF
--- a/rust/src/baq_decoder.rs
+++ b/rust/src/baq_decoder.rs
@@ -3,10 +3,9 @@
 //! This module contains the core BAQ (Block Adaptive Quantization) decoding logic for Sentinel-1 packets.
 //! It supports 3-bit, 4-bit and 5-bit BAQ modes.
 
-use rayon::prelude::*;
-use num_complex::Complex32;
 use crate::sample_value_reconstruction::reconstruct_unsigned_sample_value_baq;
-
+use num_complex::Complex32;
+use rayon::prelude::*;
 
 /// Extract an integer of the given width from a bitstream at a bit offset.
 ///
@@ -40,7 +39,11 @@ fn decode_baq_sample(data: &[u8], bit_offset: usize, baq_bits: u8, thidx: u8) ->
     let sign = (bits >> (baq_bits - 1)) & 1 == 1;
     let mcode = bits & ((1 << (baq_bits - 1)) - 1);
     let mag = reconstruct_unsigned_sample_value_baq(mcode, baq_bits, thidx);
-    if sign { -mag } else { mag }
+    if sign {
+        -mag
+    } else {
+        mag
+    }
 }
 
 /// Decode BAQ (Block Adaptive Quantization) data from Sentinel-1 packets.
@@ -59,7 +62,15 @@ fn decode_baq_sample(data: &[u8], bit_offset: usize, baq_bits: u8, thidx: u8) ->
 ///
 /// A vector of complex numbers representing the decoded samples. The samples are interleaved:
 /// - `complex(IE[0], QE[0])`, `complex(IO[0], QO[0])`, `complex(IE[1], QE[1])`, `complex(IO[1], QO[1])`, ...
-pub fn decode_single_baq_packet_inner(data: &[u8], num_quads: usize, baq_bits: u8) -> Result<Vec<Complex32>, String> {
+pub fn decode_single_baq_packet_inner(
+    data: &[u8],
+    num_quads: usize,
+    baq_bits: u8,
+) -> Result<Vec<Complex32>, String> {
+    if !matches!(baq_bits, 3 | 4 | 5) {
+        return Err(format!("Invalid BAQ bits: {}", baq_bits));
+    }
+
     // Number of BAQ blocks (128 quads per block)
     let num_baq_blocks = (num_quads + 127) / 128;
 
@@ -73,7 +84,12 @@ pub fn decode_single_baq_packet_inner(data: &[u8], num_quads: usize, baq_bits: u
     let qo_len = nw_ie_io_qo * 2;
 
     if data.len() < ie_len + io_len + qe_len + qo_len {
-        return Err(format!("Data too short for BAQ {} decoding. Expected minimum {} bytes, got {}", baq_bits, ie_len + io_len + qe_len + qo_len, data.len()));
+        return Err(format!(
+            "Data too short for BAQ {} decoding. Expected minimum {} bytes, got {}",
+            baq_bits,
+            ie_len + io_len + qe_len + qo_len,
+            data.len()
+        ));
     }
 
     let ie_data = &data[0..ie_len];
@@ -118,6 +134,20 @@ pub fn decode_single_baq_packet_inner(data: &[u8], num_quads: usize, baq_bits: u
     Ok(out)
 }
 
+/// Decode a batch of BAQ packets in parallel.
+///
+/// Each packet is decoded with [`decode_single_baq_packet_inner`] using Rayon's
+/// parallel iterator.
+///
+/// # Arguments
+///
+/// * `packets` - Encoded packet payloads
+/// * `num_quads` - Number of quad samples to decode per packet
+/// * `baq_bits` - Number of bits per sample (3, 4, or 5)
+///
+/// # Returns
+///
+/// One vector of interleaved complex samples per input packet.
 pub fn decode_batched_baq_packets_inner(
     packets: &[Vec<u8>],
     num_quads: usize,

--- a/rust/src/fdbaq_decoder.rs
+++ b/rust/src/fdbaq_decoder.rs
@@ -3,11 +3,11 @@
 //! This module contains the core FDBAQ (Flexible Dynamic Block Adaptive Quantization)
 //! decoding logic for Sentinel-1 packets.
 
-use std::sync::LazyLock;
-use rayon::prelude::*;
 use num_complex::Complex32;
+use rayon::prelude::*;
+use std::sync::LazyLock;
 
-use crate::huffman::{HuffmanDecoderSampleCode, HuffmanDecodingState, HuffmanCode};
+use crate::huffman::{HuffmanCode, HuffmanDecoderSampleCode, HuffmanDecodingState};
 use crate::huffman_codes::get_huffman_codes;
 use crate::sample_value_reconstruction::reconstruct_channel;
 
@@ -64,17 +64,23 @@ fn get_decoder(brc: u8) -> Option<&'static HuffmanDecoderSampleCode> {
 /// # Returns
 ///
 /// The reconstructed bitstream
-fn reconstruct_bitstream(excess_symbols: &Vec<(bool, u8)>, excess_symbol_codes: &Vec<HuffmanCode<(bool, u8)>>, state: HuffmanDecodingState) -> HuffmanDecodingState {
+fn reconstruct_bitstream(
+    excess_symbols: &Vec<(bool, u8)>,
+    excess_symbol_codes: &Vec<HuffmanCode<(bool, u8)>>,
+    state: HuffmanDecodingState,
+) -> HuffmanDecodingState {
     let mut bitstream = state.state_bits;
     let mut bitstream_len = state.state_len;
     for symbol in excess_symbols.iter().rev() {
-        let code = excess_symbol_codes.iter().find(|code| code.symbol == *symbol).unwrap();
+        let code = excess_symbol_codes
+            .iter()
+            .find(|code| code.symbol == *symbol)
+            .unwrap();
         bitstream |= (code.bits as u16) << bitstream_len;
         bitstream_len += code.bit_len;
     }
     HuffmanDecodingState::new(bitstream, bitstream_len)
 }
-
 
 /// Decode a channel's data (one quarter of the quad data).
 ///
@@ -125,12 +131,18 @@ fn decode_channel(
         // - BRC needs 3 bits
         // - THIDX needs 8 bits
         // - Other channels (IO, QO) need 0 bits (no header)
-        let bits_needed_for_header = if read_brc { 3 } else if read_thidx { 8 } else { 0 };
+        let bits_needed_for_header = if read_brc {
+            3
+        } else if read_thidx {
+            8
+        } else {
+            0
+        };
 
-        // CRITICAL FIX: Only fetch a new byte from `data` if the leftover bits in `state` are
+        // Only fetch a new byte from `data` if the leftover bits in `state` are
         // strictly insufficient for the header. If we unconditionally fetch a byte here (especially
         // on the last block of a channel), we might consume a byte that actually belongs to the NEXT
-        // channel. Since `state`is discarded at the end of `decode_channel`, that over-read byte
+        // channel. Since `state` is discarded at the end of `decode_channel`, that over-read byte
         // would be lost forever, causing the next channel to lose its synchronization.
         if state.state_len < bits_needed_for_header {
             if let Some(&byte) = data.get(*byte_idx) {
@@ -170,7 +182,9 @@ fn decode_channel(
             let thidx = ((boundary_state_bits >> (boundary_state_len - 8)) & 0xFF) as u8;
             thidxs.push(thidx);
 
-            brc = *brcs.get(block_idx).ok_or_else(|| format!("Not enough BRC codes for block {}", block_idx))?;
+            brc = *brcs
+                .get(block_idx)
+                .ok_or_else(|| format!("Not enough BRC codes for block {}", block_idx))?;
             let remaining_bits = boundary_state_bits & ((1 << (boundary_state_len - 8)) - 1);
             let remaining_len = boundary_state_len - 8;
             decoder = get_decoder(brc).ok_or_else(|| format!("Invalid BRC value: {}", brc))?;
@@ -178,24 +192,28 @@ fn decode_channel(
             initial_symbols = symbols;
             state = next_state;
         } else {
-            brc = *brcs.get(block_idx).ok_or_else(|| format!("Not enough BRC codes for block {}", block_idx))?;
+            brc = *brcs
+                .get(block_idx)
+                .ok_or_else(|| format!("Not enough BRC codes for block {}", block_idx))?;
             decoder = get_decoder(brc).ok_or_else(|| format!("Invalid BRC value: {}", brc))?;
-            let (symbols, next_state) = decoder.read_bitstream(boundary_state_bits, boundary_state_len);
+            let (symbols, next_state) =
+                decoder.read_bitstream(boundary_state_bits, boundary_state_len);
             initial_symbols = symbols;
             state = next_state;
         }
-
 
         // Start with symbols from BRC byte (if any)
         let mut block_symbols = initial_symbols;
 
         // Decode remaining symbols for this block
         while block_symbols.len() < symbols_needed {
-            if *byte_idx >= data.len() {
-                return Err("Unexpected end of data when decoding symbols (1)".to_string());
-            }
-            let byte = *data.get(*byte_idx)
-                .ok_or_else(|| "Unexpected end of data when decoding symbols (2)".to_string())?;
+            let byte = *data.get(*byte_idx).ok_or_else(|| {
+                format!(
+                    "Unexpected end of data when decoding symbols. Byte index {} exceeded data length {}",
+                    *byte_idx,
+                    data.len()
+                )
+            })?;
             *byte_idx += 1;
 
             let state_id = state.to_state_id();
@@ -208,7 +226,8 @@ fn decode_channel(
         // Take only the symbols we need (in case we decoded too many)
         if block_symbols.len() > symbols_needed {
             let excess_symbols = block_symbols.split_off(symbols_needed);
-            let new_block_state = reconstruct_bitstream(&excess_symbols, &decoder.huffman_tree, state);
+            let new_block_state =
+                reconstruct_bitstream(&excess_symbols, &decoder.huffman_tree, state);
             state = new_block_state;
         }
 
@@ -238,23 +257,58 @@ fn decode_channel(
 ///
 /// A vector of complex numbers representing the decoded samples. The samples are interleaved:
 /// - `complex(IE[0], QE[0])`, `complex(IO[0], QO[0])`, `complex(IE[1], QE[1])`, `complex(IO[1], QO[1])`, ...
-pub fn decode_single_fdbaq_packet_inner(data: &[u8], num_quads: usize) -> Result<Vec<Complex32>, String> {
+pub fn decode_single_fdbaq_packet_inner(
+    data: &[u8],
+    num_quads: usize,
+) -> Result<Vec<Complex32>, String> {
     let mut byte_idx = 0;
 
     let mut brcs: Vec<u8> = Vec::new();
     let mut thidxs: Vec<u8> = Vec::new();
 
     // Decode IE channel (reads BRCs)
-    let s_ie = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, true, false)?;
+    let s_ie = decode_channel(
+        data,
+        &mut byte_idx,
+        num_quads,
+        &mut brcs,
+        &mut thidxs,
+        true,
+        false,
+    )?;
 
     // Decode IO channel (reuses BRCs)
-    let s_io = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, false)?;
+    let s_io = decode_channel(
+        data,
+        &mut byte_idx,
+        num_quads,
+        &mut brcs,
+        &mut thidxs,
+        false,
+        false,
+    )?;
 
     // Decode QE channel (reuses BRCs, reads THIDXs)
-    let s_qe = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, true)?;
+    let s_qe = decode_channel(
+        data,
+        &mut byte_idx,
+        num_quads,
+        &mut brcs,
+        &mut thidxs,
+        false,
+        true,
+    )?;
 
     // Decode QO channel (reuses BRCs)
-    let s_qo = decode_channel(data, &mut byte_idx, num_quads, &mut brcs, &mut thidxs, false, false)?;
+    let s_qo = decode_channel(
+        data,
+        &mut byte_idx,
+        num_quads,
+        &mut brcs,
+        &mut thidxs,
+        false,
+        false,
+    )?;
 
     // Reconstruct the sample values
     let ie = reconstruct_channel(&s_ie, &brcs, &thidxs);
@@ -265,13 +319,12 @@ pub fn decode_single_fdbaq_packet_inner(data: &[u8], num_quads: usize) -> Result
     // Combine channels into interleaved complex samples: IE[i]+QE[i]j, IO[i]+QO[i]j, ...
     let mut complex_samples = Vec::with_capacity(ie.len() * 2);
     for i in 0..ie.len() {
-        complex_samples.push(Complex32::new(ie[i], qe[i]));  // IE[i] + QE[i]j
-        complex_samples.push(Complex32::new(io[i], qo[i]));  // IO[i] + QO[i]j
+        complex_samples.push(Complex32::new(ie[i], qe[i])); // IE[i] + QE[i]j
+        complex_samples.push(Complex32::new(io[i], qo[i])); // IO[i] + QO[i]j
     }
 
     Ok(complex_samples)
 }
-
 
 pub fn decode_batched_fdbaq_packets_inner(
     packets: &[Vec<u8>],

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,13 +1,14 @@
 //! Python bindings for Sentinel-1 decoder.
 //!
 //! This module provides Python bindings for the Rust implementation of the
-//! Sentinel-1 FDBAQ and bypass decoders.
+//! Sentinel-1 FDBAQ, BAQ, and bypass decoders.
 //!
 //! # Module Organization
 //!
 //! - `huffman.rs`: Core Huffman decoder structures and lookup table building logic
 //! - `huffman_codes.rs`: Huffman code tables for all 5 BRC values
 //! - `fdbaq_decoder.rs`: Core FDBAQ decoding logic
+//! - `baq_decoder.rs`: Core BAQ decoding logic
 //! - `bypass_decoder.rs`: Core bypass decoding logic
 //! - `lib.rs`: Python bindings and module setup
 
@@ -18,8 +19,8 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 
-mod bypass_decoder;
 mod baq_decoder;
+mod bypass_decoder;
 mod fdbaq_decoder;
 mod headers;
 mod huffman;
@@ -27,10 +28,10 @@ mod huffman_codes;
 mod lookup_tables;
 mod sample_value_reconstruction;
 
+use crate::baq_decoder::{decode_batched_baq_packets_inner, decode_single_baq_packet_inner};
 use crate::bypass_decoder::{
     decode_batched_bypass_packets_inner, decode_single_bypass_packet_inner,
 };
-use crate::baq_decoder::{decode_batched_baq_packets_inner, decode_single_baq_packet_inner};
 use crate::fdbaq_decoder::{decode_batched_fdbaq_packets_inner, decode_single_fdbaq_packet_inner};
 use crate::headers::{decode_packet_headers_inner, PacketHeaderColumns};
 

--- a/src/sentinel1decoder/l0decoder.py
+++ b/src/sentinel1decoder/l0decoder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import Optional
 
 import numpy as np
@@ -81,13 +82,12 @@ class Level0Decoder:
 
         if baq_mode == BaqMode.BYPASS_MODE:
             batch_decoder = decode_batched_bypass_packets
-        elif baq_mode in (BaqMode.BAQ_3_BIT_MODE, BaqMode.BAQ_4_BIT_MODE, BaqMode.BAQ_5_BIT_MODE):
-            bits = {BaqMode.BAQ_3_BIT_MODE: 3, BaqMode.BAQ_4_BIT_MODE: 4, BaqMode.BAQ_5_BIT_MODE: 5}[baq_mode]
-
-            def baq_batch_decoder(packets: list[bytes], num_quads: int) -> np.ndarray:
-                return decode_batched_baq_packets(packets, num_quads, bits)
-
-            batch_decoder = baq_batch_decoder
+        elif baq_mode == BaqMode.BAQ_3_BIT_MODE:
+            batch_decoder = partial(decode_batched_baq_packets, baq_bits=3)
+        elif baq_mode == BaqMode.BAQ_4_BIT_MODE:
+            batch_decoder = partial(decode_batched_baq_packets, baq_bits=4)
+        elif baq_mode == BaqMode.BAQ_5_BIT_MODE:
+            batch_decoder = partial(decode_batched_baq_packets, baq_bits=5)
         elif baq_mode in (BaqMode.FDBAQ_MODE_0, BaqMode.FDBAQ_MODE_1, BaqMode.FDBAQ_MODE_2):
             batch_decoder = decode_batched_fdbaq_packets
         else:

--- a/src/sentinel1decoder/l0file.py
+++ b/src/sentinel1decoder/l0file.py
@@ -113,7 +113,7 @@ class Level0File:
 
         Returns:
             Dict with keys: signal_type, swath_num, num_quads, baq_mode, swst,
-            swl, pri, elevation_beam_address. Values are from the first packet
+            swl, pri, elevation_beam_address, num_packets. Values are from the first packet
             in the chunk.
         """
         meta = self.get_acquisition_chunk_metadata(acquisition_chunk)
@@ -136,7 +136,7 @@ class Level0File:
         Args:
             **kwargs: Field names and values to match. Keys must be among:
                 signal_type, swath_num, num_quads, baq_mode, swst, swl, pri,
-                elevation_beam_address.
+                elevation_beam_address, num_packets.
 
         Yields:
             Chunk IDs that match all criteria.
@@ -154,16 +154,19 @@ class Level0File:
         """Categorise all acquisition chunks by signal type and swath number.
 
         Scans every chunk once and groups them into SM / IW swath-specific
-        echo/noise buckets, calibration groups, and a ``skipped`` bucket for
-        partial chunks (8-packet ECHO blocks).
+        echo/noise buckets and calibration groups. Short echo blocks (for
+        example 8-packet IW pulses with different azimuth beam steering) are
+        included with the other echoes of that swath; filter with
+        ``iter_chunks_matching`` (e.g. ``num_packets``) if you want to exclude
+        them.
 
         Returns:
-            Dict mapping category names to lists of chunk IDs.  Dynamic keys
+            Dict mapping category names to lists of chunk IDs. Dynamic keys
             include ``echo`` / ``echo_swath_10`` / ``echo_swath_11`` /
             ``echo_swath_12``, ``noise`` / ``noise_swath_10`` /
-            ``noise_swath_11`` / ``noise_swath_12``, ``skipped``, and
-            calibration types ``cal_rx``, ``cal_tx``, ``cal_epdn``,
-            ``cal_apdn``, ``cal_ta_or_txiso``, ``cal_tx_iso``.
+            ``noise_swath_11`` / ``noise_swath_12``, and calibration types
+            ``cal_rx``, ``cal_tx``, ``cal_epdn``, ``cal_apdn``,
+            ``cal_ta_or_txiso``, ``cal_tx_iso``.
         """
         iw_swaths = {10, 11, 12}
         cal_map = {
@@ -184,7 +187,7 @@ class Level0File:
 
             key: Optional[str]
             if signal_type == SignalType.ECHO:
-                key = "skipped" if len(meta) == 8 else f"echo_swath_{swath}" if swath in iw_swaths else "echo"
+                key = f"echo_swath_{swath}" if swath in iw_swaths else "echo"
             elif signal_type == SignalType.NOISE:
                 key = f"noise_swath_{swath}" if swath in iw_swaths else "noise"
             else:

--- a/tests/test_l0file.py
+++ b/tests/test_l0file.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from sentinel1decoder import _field_names as fn
+from sentinel1decoder.enums import SignalType
+from sentinel1decoder.l0file import Level0File
+
+
+def _file_from_chunks(chunks: list[tuple[int, int, SignalType, int]]) -> Level0File:
+    """Build a Level0File with synthetic packet metadata.
+
+    Each tuple is ``(chunk_id, n_packets, signal_type, swath_num)``.
+    """
+    records: list[dict[str, object]] = []
+    index: list[tuple[int, int]] = []
+    packet_num = 0
+    for chunk_id, n_packets, signal_type, swath_num in chunks:
+        for _ in range(n_packets):
+            records.append(
+                {
+                    fn.SIGNAL_TYPE_DECODED: signal_type,
+                    fn.SWATH_NUM_DECODED: swath_num,
+                }
+            )
+            index.append((chunk_id, packet_num))
+            packet_num += 1
+
+    df = pd.DataFrame(records)
+    df.index = pd.MultiIndex.from_tuples(
+        index,
+        names=[fn.ACQUISITION_CHUNK_NUM_DECODED, fn.PACKET_NUM_DECODED],
+    )
+
+    l0file = Level0File.__new__(Level0File)
+    l0file._packet_metadata = df
+    return l0file
+
+
+def test_get_chunks_summary_groups_by_signal_and_swath() -> None:
+    l0file = _file_from_chunks(
+        [
+            (0, 8, SignalType.ECHO, 10),
+            (1, 20, SignalType.ECHO, 10),
+            (2, 5, SignalType.NOISE, 11),
+            (3, 12, SignalType.ECHO, 1),
+            (4, 2, SignalType.RX_CAL, 10),
+        ]
+    )
+
+    assert l0file.get_chunks_summary() == {
+        "echo_swath_10": [0, 1],
+        "noise_swath_11": [2],
+        "echo": [3],
+        "cal_rx": [4],
+    }


### PR DESCRIPTION
Semantic changes (ignore wrapping / import order / extra newlines in the Rust files):

Reject invalid BAQ widths (3|4|5) in decode_single_baq_packet_inner instead of panicking later
Docstring on decode_batched_baq_packets_inner
FDBAQ: one “unexpected end of data” error (index + length); drop the (1)/(2) split
Tone down the FDBAQ boundary-byte comment (no “CRITICAL FIX”; `state` is)
BAQ dispatch: separate elifs + partial(..., baq_bits=3/4/5) instead of a nested decoder
lib.rs crate docs list BAQ / baq_decoder.rs
get_chunks_summary: no skipped bucket — 8-packet echoes stay with the other echoes of that swath
Document num_packets on get_acquisition_chunk_constants and as an iter_chunks_matching filter
Test: tests/test_l0file.py for summary grouping (including 8-packet IW echo)

Noise in the same diff: rustfmt on baq_decoder.rs / fdbaq_decoder.rs (and a couple of mod/use reorderings in lib.rs).